### PR TITLE
Add query param to get around Github cache issue

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -8,7 +8,7 @@ datasheets
 .. |travis_ci| image:: https://travis-ci.org/Squarespace/datasheets.svg?branch=master
     :target: https://travis-ci.org/Squarespace/datasheets
 
-.. |coveralls| image:: https://coveralls.io/repos/github/Squarespace/datasheets/badge.svg?branch=master
+.. |coveralls| image:: https://coveralls.io/repos/github/Squarespace/datasheets/badge.svg?branch=master&service=github
     :target: https://coveralls.io/github/Squarespace/datasheets?branch=master
 
 


### PR DESCRIPTION
Github caches resources. This causes issues with badges. The specific
example here was a Coveralls result saying we have 0% test coverage,
which then became the cached badge result for our README page. Even
though we re-ran Travis to get the correct code coverage amount (96%),
we can't get the 0% badge to go away, even when clearing the local
browser cache. Again, this is because it is actually Github itself that
is caching the resources. According to the Coveralls issue below, one
solution is to use query string params. Even with static query string
parameters, there is a tendency for them to invalidate cache resources,
so we'll give that a shot.

This will likely work in the short-term regardless: this is a different
resource URL so Github's cache will be invalid. As a result, we won't
actually know if this solves the real issue until a similar situation
arises in the future.

Issue mentioned above:
    https://github.com/lemurheavy/coveralls-public/issues/971