### PR TITLE
Switch to google auth

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -14,12 +14,12 @@ datasheets
 
 datasheets is a library for interfacing with Google Sheets, including reading data from, writing
 data to, and modifying the formatting of Google Sheets. It is built on top of Google's
-`google-api-python-client`_, `google_auth`_, and `_google_auth_oauthlib`_ libraries using the `Google Drive v3`_ and
+`google-api-python-client`_, `google_auth`_, and `google_auth_oauthlib`_ libraries using the `Google Drive v3`_ and
 `Google Sheets v4`_ REST APIs.
 
 .. _google-api-python-client: https://github.com/google/google-api-python-client
 .. _google_auth: https://github.com/GoogleCloudPlatform/google-auth-library-python
-.. _google_auth_oauthlib https://github.com/GoogleCloudPlatform/google-auth-library-python-oauthlib
+.. _google_auth_oauthlib: https://github.com/GoogleCloudPlatform/google-auth-library-python-oauthlib
 .. _Google Drive v3: https://developers.google.com/drive/v3/reference/
 .. _Google Sheets v4: https://developers.google.com/sheets/reference/rest/
 

--- a/README.rst
+++ b/README.rst
@@ -14,11 +14,12 @@ datasheets
 
 datasheets is a library for interfacing with Google Sheets, including reading data from, writing
 data to, and modifying the formatting of Google Sheets. It is built on top of Google's
-`google-api-python-client`_ and `oauth2client`_ libraries using the `Google Drive v3`_ and
+`google-api-python-client`_, `google_auth`_, and `_google_auth_oauthlib`_ libraries using the `Google Drive v3`_ and
 `Google Sheets v4`_ REST APIs.
 
 .. _google-api-python-client: https://github.com/google/google-api-python-client
-.. _oauth2client: https://github.com/google/oauth2client
+.. _google_auth: https://github.com/GoogleCloudPlatform/google-auth-library-python
+.. _google_auth_oauthlib https://github.com/GoogleCloudPlatform/google-auth-library-python-oauthlib
 .. _Google Drive v3: https://developers.google.com/drive/v3/reference/
 .. _Google Sheets v4: https://developers.google.com/sheets/reference/rest/
 

--- a/datasheets/__init__.py
+++ b/datasheets/__init__.py
@@ -1,11 +1,11 @@
 """
 datasheets is a library for interfacing with Google Sheets, including reading from, writing to,
 and modifying the formatting of Google Sheets. It is built on top of Google's
-google-api-python-client and oauth2client libraries using the Google Drive v3 and Google Sheets
+google-api-python-client and google_auth libraries using the Google Drive v3 and Google Sheets
 v4 REST APIs. Further details on these libraries and APIs can be found here:
 
     google-api-python-client: https://github.com/google/google-api-python-client
-    oauth2client: https://github.com/google/oauth2client
+    google_auth: https://github.com/GoogleCloudPlatform/google-auth-library-python
     Drive v3: https://developers.google.com/drive/v3/reference/
     Sheets v4: https://developers.google.com/sheets/reference/rest/
 """

--- a/datasheets/client.py
+++ b/datasheets/client.py
@@ -132,7 +132,11 @@ class Client(object):
         unexpanded_client_secrets_path = os.environ.get('DATASHEETS_SECRETS_PATH',
                                                         '~/.datasheets/client_secrets.json')
         client_secrets_path = os.path.expanduser(unexpanded_client_secrets_path)
-        scope = ['https://www.googleapis.com/auth/drive', 'https://www.googleapis.com/auth/userinfo.email', 'https://www.googleapis.com/auth/plus.me']
+        scope = [
+            'https://www.googleapis.com/auth/drive',
+            'https://www.googleapis.com/auth/userinfo.email',
+            'https://www.googleapis.com/auth/plus.me'
+        ]
         flow = InstalledAppFlow.from_client_secrets_file(
             client_secrets_path,
             scopes=scope)

--- a/datasheets/client.py
+++ b/datasheets/client.py
@@ -1,16 +1,15 @@
+import apiclient
 import json
 import os
-import types
-
-import apiclient
 import pandas as pd
-
-from datasheets import exceptions, helpers
-from datasheets.workbook import Workbook
+import types
+from google.auth.transport.requests import Request
 from google.oauth2 import service_account
 from google.oauth2.credentials import Credentials
 from google_auth_oauthlib.flow import InstalledAppFlow
-from google.auth.transport.requests import Request
+
+from datasheets import exceptions, helpers
+from datasheets.workbook import Workbook
 
 
 class Client(object):

--- a/datasheets/client.py
+++ b/datasheets/client.py
@@ -244,7 +244,7 @@ class Client(object):
         time this method returns the instance has not yet been authenticated / authorized.
 
         Returns:
-            oauth2client.service_account.ServiceAccountCredentials: instance of service credentials
+            google.oauth2.service_account.Credentials: instance of service credentials
         """
         unexpanded_service_key_path = os.environ.get('DATASHEETS_SERVICE_PATH',
                                                      '~/.datasheets/service_key.json')

--- a/datasheets/client.py
+++ b/datasheets/client.py
@@ -109,7 +109,7 @@ class Client(object):
             credential_path = os.path.expanduser(unexpanded_credential_path)
             try:
                 credentials = Credentials.from_authorized_user_file(credential_path)
-            except FileNotFoundError:
+            except IOError:
                 credentials = self._fetch_new_client_credentials()
                 data = {
                         "refresh_token": credentials.refresh_token,

--- a/datasheets/client.py
+++ b/datasheets/client.py
@@ -122,6 +122,7 @@ class Client(object):
                     json.dump(data, f)
         else:
             credentials = self._fetch_new_client_credentials()
+        self.email = "user's personal email address"
         return credentials
 
     def _fetch_new_client_credentials(self):

--- a/datasheets/client.py
+++ b/datasheets/client.py
@@ -69,8 +69,7 @@ class Client(object):
         requested_attr = super(Client, self).__getattribute__(attr)
 
         if isinstance(requested_attr, types.MethodType) \
-           and not attr.startswith('_') \
-           and hasattr(self, 'credentials'):
+           and not attr.startswith('_'):
             self._refresh_token_if_needed()
 
         return requested_attr

--- a/datasheets/client.py
+++ b/datasheets/client.py
@@ -1,8 +1,9 @@
-import apiclient
 import json
 import os
-import pandas as pd
 import types
+
+import apiclient
+import pandas as pd
 from google.auth.transport.requests import Request
 from google.oauth2 import service_account
 from google.oauth2.credentials import Credentials

--- a/datasheets/helpers.py
+++ b/datasheets/helpers.py
@@ -9,10 +9,9 @@ import datetime as dt
 import sys
 
 import numpy as np
-from oauth2client.file import Storage
-from oauth2client.client import AccessTokenCredentialsError
 import pandas as pd
-
+from oauth2client.client import AccessTokenCredentialsError
+from oauth2client.file import Storage
 
 # Note: dates, times, and datetimes in Google Sheets are represented in 'serial number' format
 # as explained here: https://developers.google.com/sheets/reference/rest/v4/DateTimeRenderOption

--- a/datasheets/tab.py
+++ b/datasheets/tab.py
@@ -1,5 +1,5 @@
-from collections import OrderedDict
 import types
+from collections import OrderedDict
 
 import apiclient
 import pandas as pd

--- a/docs/comparison_to_gspread.rst
+++ b/docs/comparison_to_gspread.rst
@@ -14,9 +14,9 @@ for this project. datasheets attempts to improve on gspread by:
 * Providing a number of additional tools for interacting with Google Sheets: format them, add/remove
   rows and columns, create or delete tabs and workbooks, share or unshare a workbook with users,
   etc. See below for more details.
-* Using more modern, Google-maintained tools (e.g. Google's `google-api-python-client`_ and `oauth2client`_
+* Using more modern, Google-maintained tools (e.g. Google's `google-api-python-client`_ and `google_auth`_
   libraries) as opposed to parsing XML feeds.
 
 .. _gspread: https://github.com/burnash/gspread
 .. _google-api-python-client: https://github.com/google/google-api-python-client
-.. _oauth2client: https://github.com/google/oauth2client) libraries using the
+.. _google_auth: https://github.com/GoogleCloudPlatform/google-auth-library-python

--- a/docs/getting_oauth_credentials.rst
+++ b/docs/getting_oauth_credentials.rst
@@ -69,14 +69,6 @@ To set this up:
 
 3. Select 'Other' to create an installed app and input a name.
 
-    |
-
-    .. note:: Don't forget the forward slash at the end of the Authorized redirect URIs or you will
-        get an error!
-
-    .. image:: images/create_oauth_client_settings.png
-        :scale: 65%
-
 4. After clicking 'Create' and then 'Ok' on the following screen, click the download button.
 
     .. image:: images/download_oauth_client_secrets.png

--- a/docs/getting_oauth_credentials.rst
+++ b/docs/getting_oauth_credentials.rst
@@ -67,7 +67,7 @@ To set this up:
     .. image:: images/create_oauth_client_id_button.png
         :scale: 65%
 
-3. Select 'Other' to create an internal app and  input a name.
+3. Select 'Other' to create an installed app and input a name.
 
     |
 

--- a/docs/getting_oauth_credentials.rst
+++ b/docs/getting_oauth_credentials.rst
@@ -67,10 +67,7 @@ To set this up:
     .. image:: images/create_oauth_client_id_button.png
         :scale: 65%
 
-3. Select 'Web application', input a name, and enter Authorized JavaScript origins and Authorized
-   redirect URIs. The Authorized JavaScript origins are ``http://localhost:8888`` and
-   ``http://localhost:8080``. The Authorized redirect URIs are the same **except with a forward
-   slash (/) appended**.
+3. Select 'Other' to create an internal app and  input a name.
 
     |
 

--- a/docs/getting_oauth_credentials.rst
+++ b/docs/getting_oauth_credentials.rst
@@ -4,10 +4,10 @@ Getting OAuth Credentials
 To utilize datasheets, you'll need to get it connected to your Google Drive and Google Sheets
 repositories. There are two possible ways to do this: user-granted authorization ('OAuth Client ID')
 or the use of a service account ('OAuth Service Account'), both of which are implemented through the
-underlying Google `oauth2client`_ library. A description of both authentication mechanisms follows
+underlying Google `google_auth`_ library. A description of both authentication mechanisms follows
 below, but before we can use either mechanism we need to create a project.
 
-.. _oauth2client: https://github.com/google/oauth2client
+.. _google_auth: https://github.com/GoogleCloudPlatform/google-auth-library-python
 
 Setting Up A Project
 --------------------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -3,11 +3,11 @@ Overview
 
 datasheets is a library for interfacing with Google Sheets, including reading data from, writing
 data to, and modifying the formatting of Google Sheets. It is built on top of Google's
-`google-api-python-client`_ and `oauth2client`_ libraries using the `Google Drive v3`_ and
+`google-api-python-client`_ and `google_auth`_ libraries using the `Google Drive v3`_ and
 `Google Sheets v4`_ REST APIs.
 
 .. _google-api-python-client: https://github.com/google/google-api-python-client
-.. _oauth2client: https://github.com/google/oauth2client
+.. _google_auth: https://github.com/GoogleCloudPlatform/google-auth-library-python
 .. _Google Drive v3: https://developers.google.com/drive/v3/reference/
 .. _Google Sheets v4: https://developers.google.com/sheets/reference/rest/
 

--- a/setup.py
+++ b/setup.py
@@ -23,10 +23,8 @@ required = [
     'google_auth_oauthlib',
     'pandas',
     'numpy',
-    'oauth2client>=2.0.2',  # Bugs in 2.0.1 and below
     'google-api-python-client>=1.5.4',
     'six>=1.10.0',  # required by google-api-python-client but not installed by it
-    'PyOpenSSL',  # used by oauth2client
     'httplib2!=0.10.2',  # Skip 0.10.2 becauses it causes httplib2.CertificateValidationUnsupported error
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,8 @@ def get_version():
 
 
 required = [
+    'google_auth',
+    'google_auth_oauthlib',
     'pandas',
     'numpy',
     'oauth2client>=2.0.2',  # Bugs in 2.0.1 and below

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -57,7 +57,7 @@ def sheets_svc():
 @pytest.fixture
 def mock_client(mocker, drive_svc, sheets_svc):
     mocker.patch('datasheets.Client._authenticate')
-    mocker.patch('datasheets.Client.http', create=True)
+    mocker.patch('datasheets.Client.credentials', create=True)
     mocker.patch('apiclient.discovery.build', autospec=True,
                  side_effect=[drive_svc, sheets_svc])
     mocker.patch('datasheets.Client._refresh_token_if_needed')

--- a/tests/manual_testing.ipynb
+++ b/tests/manual_testing.ipynb
@@ -16,7 +16,8 @@
     "import datetime as dt\n",
     "import random\n",
     "\n",
-    "import oauth2client\n",
+    "from google.oauth2.credentials import Credentials as base_credentials\n",
+    "from google.oauth2.service_account import Credentials as service_credentials\n",
     "import pandas as pd\n",
     "\n",
     "import datasheets"
@@ -37,7 +38,7 @@
    "source": [
     "# Can create a non-service account\n",
     "nonsvc_client = datasheets.Client()\n",
-    "assert isinstance(nonsvc_client.credentials, oauth2client.client.OAuth2Credentials)\n",
+    "assert isinstance(nonsvc_client.credentials, base_credentials)\n",
     "assert not hasattr(nonsvc_client.credentials, 'service_account_email')\n",
     "del nonsvc_client"
    ]
@@ -50,7 +51,7 @@
    "source": [
     "# Can create a service account\n",
     "service_client = datasheets.Client(service=True)\n",
-    "assert isinstance(service_client.credentials, oauth2client.service_account.ServiceAccountCredentials)\n",
+    "assert isinstance(service_client.credentials, service_credentials)\n",
     "assert hasattr(service_client.credentials, 'service_account_email')\n",
     "del service_client"
    ]

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -341,7 +341,7 @@ def test_get_service_credentials_envvar_set(mocker, tmpdir):
 
 
 @pytest.mark.usefixtures('clear_envvars')
-def test_fetch_new_client_credentials_envvar_set(tmpdir):
+def test_fetch_new_client_credentials_envvar_set(mocker, tmpdir):
     # Use a non-standard filename and file ending to ensure they work
     file_path = tmpdir.join('my_client_secrets_file.foo')
     # Credentials were built by taking an existing secrets file and manually smudging it
@@ -358,7 +358,11 @@ def test_fetch_new_client_credentials_envvar_set(tmpdir):
     """)
     os.environ['DATASHEETS_SECRETS_PATH'] = file_path.strpath
 
-    flow = InstalledAppFlow.from_client_secrets_file(os.environ['DATASHEETS_SECRETS_PATH'] , [])
+    mocker.patch.object(datasheets.Client, '__init__', return_value=None)
+    mocker.patch.object(InstalledAppFlow, 'run_local_server', autospec=True, side_effect=lambda self, port: self)
+    client = datasheets.Client()
+    client.user_agent = "Test"
+    flow = client._fetch_new_client_credentials()
     config = flow.client_config
     assert isinstance(flow, InstalledAppFlow)
     assert config["client_id"] == '562803761647-1lj6fdt4rk27qde3f61slphbqcr9mieh.apps.googleusercontent.com'

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -402,9 +402,7 @@ def test_retrieve_client_credentials_use_storage_and_envvar_set(mocker, tmpdir):
         "token_type": "Bearer"},
         "scopes": ["https://www.googleapis.com/auth/drive", "https://www.googleapis.com/auth/userinfo.email"],
         "token_info_uri": "https://www.googleapis.com/oauth2/v3/tokeninfo",
-        "invalid": false,
-        "_class": "OAuth2Credentials",
-        "_module": "oauth2client.client"
+        "invalid": false
     }""")
     os.environ['DATASHEETS_CREDENTIALS_PATH'] = file_path.strpath
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -421,6 +421,22 @@ def test_retrieve_client_credentials_no_storage(mocker):
     assert credentials == mocked_fetch_new()
 
 
+def test_stores_credentials_when_not_found(mocker):
+    credentials = base_credentials("token", refresh_token="refresh_token", client_id="client_id",
+                                   client_secret="client_secret")
+
+    os.environ['DATASHEETS_CREDENTIALS_PATH'] = "./test_stores_credentials_when_not_found.json"
+    mocker.patch.object(datasheets.Client, '__init__', return_value=None)
+    mocker.patch.object(datasheets.Client, '_fetch_new_client_credentials',
+                        return_value=credentials, autospec=True)
+    client = datasheets.Client()
+    client.use_storage = True
+    client._retrieve_client_credentials()
+    with open(os.environ['DATASHEETS_CREDENTIALS_PATH']) as file:
+        assert file.read() == '{"refresh_token": "refresh_token", "client_id": "client_id", "client_secret": "client_secret"}'
+    os.remove(os.environ['DATASHEETS_CREDENTIALS_PATH'])
+
+
 def test_create_workbook_no_folder(mocker, mock_client):
     filename = 'test_create_workbook'
     file_id = 'xyz1234'

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -431,6 +431,7 @@ def test_stores_credentials_when_not_found(mocker):
                         return_value=credentials, autospec=True)
     client = datasheets.Client()
     client.use_storage = True
+    client.email = "Test"
     client._retrieve_client_credentials()
     with open(os.environ['DATASHEETS_CREDENTIALS_PATH']) as file:
         assert file.read() == '{"refresh_token": "refresh_token", "client_id": "client_id", "client_secret": "client_secret"}'

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,14 +1,13 @@
-import os
-
 import apiclient
-import oauth2client
+import os
 import pandas as pd
 import pytest
+from google.oauth2.credentials import Credentials as base_credentials
+from google.oauth2.service_account import Credentials as service_credentials
+from google_auth_oauthlib.flow import InstalledAppFlow
 
 import datasheets
-from google.oauth2.service_account import Credentials as service_credentials
-from google.oauth2.credentials import Credentials as base_credentials
-from google_auth_oauthlib.flow import InstalledAppFlow
+
 
 @pytest.fixture
 def clear_envvars():
@@ -410,7 +409,6 @@ def test_retrieve_client_credentials_use_storage_and_envvar_set(mocker, tmpdir):
     client.use_storage = True
     credentials = client._retrieve_client_credentials()
     assert mocked_fetch_new.call_count == 0
-    print(type(credentials))
     assert isinstance(credentials, base_credentials)
 
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -360,7 +360,7 @@ def test_fetch_new_client_credentials_envvar_set(mocker, tmpdir):
     os.environ['DATASHEETS_SECRETS_PATH'] = file_path.strpath
 
     mocker.patch.object(datasheets.Client, '__init__', return_value=None)
-    mocker.patch.object(InstalledAppFlow, 'run_local_server', autospec=True, side_effect=lambda self, port: self)
+    mocker.patch.object(InstalledAppFlow, 'run_local_server', autospec=True, side_effect=lambda appflow_instance, port: appflow_instance)
     client = datasheets.Client()
     client.user_agent = "Test"
     flow = client._fetch_new_client_credentials()

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,5 +1,6 @@
 import apiclient
 import os
+import json
 import pandas as pd
 import pytest
 from google.oauth2.credentials import Credentials as base_credentials
@@ -434,7 +435,8 @@ def test_stores_credentials_when_not_found(mocker):
     client.email = "Test"
     client._retrieve_client_credentials()
     with open(os.environ['DATASHEETS_CREDENTIALS_PATH']) as file:
-        assert file.read() == '{"refresh_token": "refresh_token", "client_id": "client_id", "client_secret": "client_secret"}'
+        expected_string = '{"refresh_token": "refresh_token", "client_id": "client_id", "client_secret": "client_secret"}'
+        assert json.loads(file.read()) == json.loads(expected_string)
     os.remove(os.environ['DATASHEETS_CREDENTIALS_PATH'])
 
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -360,7 +360,8 @@ def test_fetch_new_client_credentials_envvar_set(mocker, tmpdir):
     os.environ['DATASHEETS_SECRETS_PATH'] = file_path.strpath
 
     mocker.patch.object(datasheets.Client, '__init__', return_value=None)
-    mocker.patch.object(InstalledAppFlow, 'run_local_server', autospec=True, side_effect=lambda appflow_instance, port: appflow_instance)
+    mocker.patch.object(InstalledAppFlow, 'run_local_server', autospec=True,
+                        side_effect=lambda appflow_instance, port: appflow_instance)
     client = datasheets.Client()
     client.user_agent = "Test"
     flow = client._fetch_new_client_credentials()

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -55,13 +55,6 @@ def test_getattribute_for_private_method(mock_client):
     assert mock_client._refresh_token_if_needed.call_count == 1
 
 
-def test_getattribute_for_user_facing_method_without_credentials(mocker, mock_client):
-    mocker.patch.object(mock_client, 'fetch_workbook', return_value='foo')
-    mock_client.fetch_workbook()
-    # _refresh_token_if_needs is called in __init__(); verify it wasn't called again
-    assert mock_client._refresh_token_if_needed.call_count == 1
-
-
 def test_getattribute_for_user_facing_method_with_credentials(mocker, mock_client):
     mock_client.credentials = 'foo'
     mocker.patch.object(mock_client, 'fetch_workbook', return_value='foo')

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,6 +1,7 @@
-import apiclient
-import os
 import json
+import os
+
+import apiclient
 import pandas as pd
 import pytest
 from google.oauth2.credentials import Credentials as base_credentials

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -427,22 +427,21 @@ def test_retrieve_client_credentials_no_storage(mocker):
     assert credentials == mocked_fetch_new()
 
 
-def test_stores_credentials_when_not_found(mocker):
+def test_stores_credentials_when_not_found(mocker, tmpdir):
     credentials = base_credentials("token", refresh_token="refresh_token", client_id="client_id",
                                    client_secret="client_secret")
 
-    os.environ['DATASHEETS_CREDENTIALS_PATH'] = "./test_stores_credentials_when_not_found.json"
+    file_path = tmpdir.join("test_stores_credentials_when_not_found.json")
+    os.environ['DATASHEETS_CREDENTIALS_PATH'] = file_path.strpath
     mocker.patch.object(datasheets.Client, '__init__', return_value=None)
     mocker.patch.object(datasheets.Client, '_fetch_new_client_credentials',
                         return_value=credentials, autospec=True)
     client = datasheets.Client()
     client.use_storage = True
-    client.email = "Test"
     client._retrieve_client_credentials()
     with open(os.environ['DATASHEETS_CREDENTIALS_PATH']) as file:
         expected_string = '{"refresh_token": "refresh_token", "client_id": "client_id", "client_secret": "client_secret"}'
         assert json.loads(file.read()) == json.loads(expected_string)
-    os.remove(os.environ['DATASHEETS_CREDENTIALS_PATH'])
 
 
 def test_create_workbook_no_folder(mocker, mock_client):

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -5,7 +5,6 @@ import datetime as dt
 import sys
 
 import numpy as np
-import oauth2client
 import pandas as pd
 import pytest
 
@@ -100,34 +99,6 @@ def test_remove_trailing_nones(array, expected):
 ])
 def test_resize_row(array, new_len, expected):
     assert expected == helpers._resize_row(array, new_len)
-
-
-def test_mock_storage():
-    mock_storage = helpers._MockStorage()
-    mock_storage.put('bar')
-    with pytest.raises(oauth2client.client.AccessTokenCredentialsError) as err:
-        mock_storage.locked_get()
-
-    assert err.match('Please create a new datasheets.Client instance')
-
-
-def test_remove_sys_argv():
-    # If this test breaks halfway through then we lose our sys.argv,
-    # but it's assumed not to matter too much in this situation
-    original_argv = copy.deepcopy(sys.argv)
-    with helpers._remove_sys_argv():
-        assert sys.argv == []
-    assert sys.argv == original_argv
-
-
-def test_suppress_stdout(capsys):
-    print('foo')
-    with helpers._suppress_stdout():
-        print('bar')
-    print('baz')
-
-    out, _ = capsys.readouterr()
-    assert out == 'foo\nbaz\n'
 
 
 class TestMakeListOfLists:

--- a/tests/test_tab.py
+++ b/tests/test_tab.py
@@ -2,8 +2,8 @@ import apiclient
 import httplib2
 import pandas as pd
 import pytest
-
 from conftest import get_data_from_yaml
+
 import datasheets
 
 


### PR DESCRIPTION
https://github.com/Squarespace/datasheets/issues/5

Switch datasheets over to google auth instead of oauth2client. Also adding google_auth_oauthlib as a dependency in order to use its flow functionality which is no longer a part of google auth. This will require a breaking change in authentication as now users will need to use installed apps instead of web apps when they create their credentials. I have updated that in a few places but I may have missed some.

@zcmarine What do I do with this section ```"installed": {
                "client_id":"562138271922-9kt0cvbh78fv0p24b4b76uj0b5vq7e0o.apps.googleusercontent.com",	                "client_id":"562803761647-1lj6fdt4rk27qde3f61slphbqcr9mieh.apps.googleusercontent.com",
                "project_id":"datasheets-etl",	                "project_id":"gsheets-etl",
                "auth_uri":"https://accounts.google.com/o/oauth2/auth",	                "auth_uri":"https://accounts.google.com/o/oauth2/auth",
                "token_uri":"https://accounts.google.com/o/oauth2/token",	                "token_uri":"https://www.googleapis.com/oauth2/v3/token",
                "auth_provider_x509_cert_url":"https://www.googleapis.com/oauth2/v1/certs",	                "auth_provider_x509_cert_url":"https://www.googleapis.com/oauth2/v1/certs",
                "client_secret":"GIacz91bpsk2j1hIEUVyzpjq",	                "client_secret":"yMWIX9SijX-nUgvFGqkzoSBb",
                "redirect_uris":["http://localhost:8080/","http://localhost:8888/"],	                "redirect_uris":["urn:ietf:wg:oauth:2.0:oob","http://localhost"]}}``` How do I generate a credential that works but isn't going to modify anything? I have already deleted this credential so it no longer works but what do I put here?

Any and all feedback appreciated.