### PR TITLE
Throw error on cell formula error

### DIFF
--- a/datasheets/exceptions.py
+++ b/datasheets/exceptions.py
@@ -23,3 +23,7 @@ class TabNotFound(DatasheetsException):
 
 class WorkbookNotFound(DatasheetsException):
     """ Trying to open non-existent or inaccessible workbook """
+
+
+class FetchDataError(DatasheetsException):
+    """ Error occurred when fetching tab data """

--- a/tests/test_tab.py
+++ b/tests/test_tab.py
@@ -226,6 +226,32 @@ def test_process_rows_type_errors(mock_tab, expected_data):
     assert err.match('Mismatch exists in expected and actual data types')
 
 
+def test_process_rows_cell_error_values(mock_tab):
+    data = {
+        'sheets': [
+            {'data': [
+                {'rowData': [
+                    {'values': [{'effectiveValue': {'numberValue': 2}}]},
+                    {'values': [{}, {'effectiveValue': {'stringValue': 'foo'}}]},
+                    {'values': [{}, {
+                        'effectiveValue': {
+                            'errorValue': {
+                                'type': 'NAME',
+                                'message': "Unknown range name: 'FOO'.",
+                            }
+                        }
+                    }]}
+                ]}
+            ]}
+        ]
+    }
+    with pytest.raises(datasheets.exceptions.FetchDataError) as err:
+        mock_tab._process_rows(data)
+    assert err.match(
+        'Error of type "NAME" within cell B3 prevents fetching data. Message: "Unknown range name: \'FOO\'."'
+    )
+
+
 def test_fetch_data_empty(mock_tab):
     mock_tab.sheets_svc.get().execute.return_value = {'sheets': [{'data': [{}]}]}
 


### PR DESCRIPTION
If a cell in a Google Sheet has a formula error (for example, the cell
has the formula '=1/0'), then running fetch_data() will fail as the cell
in question has no data: it only has the error.

Previous to this commit we didn't surface this information, leading to a
confusing stack trace that didn't indicate that the culprit was a cell
formula error (see issue #11 as a motivating example for this change).

This commit raises an exception when we have a cell formula error,
indicating the cell that errored and also passing along Google Sheets'
formula error for that cell. An example error message:
`FetchDataError: Error of type "DIVIDE_BY_ZERO" within cell B3 prevents fetching data. Message: "Function DIVIDE parameter 2 cannot be zero."`

Note that this approach throws an error at the first formula error that is
encountered; any other formula errors that exist will not be reported as
the library didn't reach them before exiting execution.

